### PR TITLE
Use more configuration agnostic ways of fetching IP info

### DIFF
--- a/src/Widgets/Page.vala
+++ b/src/Widgets/Page.vala
@@ -110,7 +110,7 @@ namespace Network.Widgets {
         public virtual void update () {
             if (info_box != null) {
                 string sent_bytes, received_bytes;
-                this.get_activity_information (device.get_iface (), out sent_bytes, out received_bytes);
+                this.get_activity_information (device.get_ip_iface (), out sent_bytes, out received_bytes);
                 info_box.update_activity (sent_bytes, received_bytes);       
             }
 


### PR DESCRIPTION
Previously, the displayed information about what IP address was being used on an interface came out of the DHCP config which is obviously only relevant if the interface was set up with DHCP. This resulted in no IP address information being shown for cellular modems as these are PPP connections.

Secondly, there's an important distinction between `get_iface` and `get_ip_iface`. In a lot of cases, they're the same. But often in the case of cellular modems, the `iface` is the TTY port that NetworkManager uses to control the modem and the actual network interface receiving bytes is called something else, usually `ppp0`. Therefore, we need to get that name using `get_ip_iface` instead.

For testing, this should have no effect on the normal functionality of the switchboard plug. IP addresses and data usage stats should display as normal. However, it allows me to get that information for cellular modems, which currently isn't possible on master.