### PR TITLE
Activate row when selected

### DIFF
--- a/src/Widgets/DeviceList.vala
+++ b/src/Widgets/DeviceList.vala
@@ -44,6 +44,10 @@ namespace Network.Widgets {
             this.show_no_devices (!show);
             this.add_proxy ();
             this.add_vpn ();
+
+            row_selected.connect ((row) => {
+                row.activate ();
+            });
         }
 
         public void add_iface_to_list (WidgetNMInterface iface) {


### PR DESCRIPTION
This activates rows when selected so that when navigating with the keyboard the selected row opens, as there is no benefit to selecting a row but not activating it.

Fixes #6 