### PR TITLE
Rewrite HotSpotDialog.vala

### DIFF
--- a/src/Widgets/Hotspot/HotspotDialog.vala
+++ b/src/Widgets/Hotspot/HotspotDialog.vala
@@ -22,35 +22,25 @@ namespace Network.Widgets {
         private const string NEW_ID = "0";
         private Gtk.Entry ssid_entry;
         private Gtk.Entry key_entry;
-
         private Gtk.Label ssid_label;
         private Gtk.Label key_label;
-
         private Gtk.ComboBoxText conn_combo;
-
         private Gtk.CheckButton check_btn;
-        private Gtk.Label dumb;
-
         private Gtk.Button create_btn;
 
         private HashTable<string, NM.Connection> conn_hash;
         private unowned List<NM.Connection> available;
 
         public HotspotDialog (NM.AccessPoint? active, List<NM.Connection> _available) {
+            Object (
+                deletable: false,
+                resizable: false,
+                window_position: Gtk.WindowPosition.CENTER_ON_PARENT
+            );
+
             this.available = _available;
-            this.deletable = false;
-            this.resizable = false;
-            this.border_width = 6;
 
             conn_hash = new HashTable<string, NM.Connection> (str_hash, str_equal);
-
-            var content_area = this.get_content_area ();
-            content_area.halign = content_area.valign = Gtk.Align.CENTER;
-
-            var main_box = new Gtk.Box (Gtk.Orientation.HORIZONTAL, 0);
-            var vbox = new Gtk.Box (Gtk.Orientation.VERTICAL, 6);
-
-            vbox.margin_left = vbox.margin_right = 6;
 
             string? ssid_str = null;
             if (active != null) {
@@ -59,32 +49,26 @@ namespace Network.Widgets {
                 ssid_str = _("current");
             }
 
-            var title = new Gtk.Label ("<span weight='bold' size='larger'>" + _("Wireless Hotspot") + "</span>");
-            title.use_markup = true;
-            title.halign = Gtk.Align.START;
-
             var image = new Gtk.Image.from_icon_name ("network-wireless-hotspot", Gtk.IconSize.DIALOG);
             image.valign = Gtk.Align.START;
-            main_box.add (image);
 
-            var info_label = new Gtk.Label (_("Enabling Wireless Hotspot will disconnect from %s network.").printf (ssid_str) + "\n" +
+            var title = new Gtk.Label (_("Wireless Hotspot"));
+            title.get_style_context ().add_class ("primary");   
+            title.xalign = 0;
+
+            var info_label = new Gtk.Label (_("Enabling Wireless Hotspot will disconnect from %s network.").printf (ssid_str) + " " +
             _("You will not be able to connect to a wireless network while Hotspot is active."));
-            info_label.halign = Gtk.Align.START;
-            info_label.margin_top = 6;
-            info_label.use_markup = true;
-
-            var grid = new Gtk.Grid ();
-            grid.hexpand = true;
-            grid.row_spacing = 6;
-            grid.column_spacing = 12;
-            grid.vexpand_set = true;
+            info_label.xalign = 0;
+            info_label.margin_bottom = 12;
+            info_label.max_width_chars = 60;
+            info_label.selectable = true;
+            info_label.wrap = true;
 
             ssid_entry = new Gtk.Entry ();
             ssid_entry.hexpand = true;
             ssid_entry.text = get_ssid_for_hotspot ();
 
             key_entry = new Gtk.Entry ();
-            key_entry.hexpand = true;
             key_entry.visibility = false;
             key_entry.secondary_icon_tooltip_text = _("Password needs to be at least 8 characters long.");
 
@@ -104,6 +88,7 @@ namespace Network.Widgets {
 
             conn_combo = new Gtk.ComboBoxText ();
             conn_combo.append (NEW_ID, _("New…"));
+
             int i = 1;
             foreach (var connection in available) {
                 var setting_wireless = connection.get_setting_wireless ();
@@ -118,38 +103,41 @@ namespace Network.Widgets {
             var conn_label = new Gtk.Label (_("Connection:"));
             conn_label.halign = Gtk.Align.END;
 
-            grid.attach (conn_label, 0, 0, 1, 1);
-            grid.attach_next_to (conn_combo, conn_label, Gtk.PositionType.RIGHT, 1, 1);
+            var main_grid = new Gtk.Grid ();
+            main_grid.column_spacing = 12;
+            main_grid.row_spacing = 6;
+            main_grid.margin = 10;
+            main_grid.margin_top = 0;
+            main_grid.attach (image, 0, 0, 1, 6);
+            main_grid.attach (title, 1, 0, 2, 1);
+            main_grid.attach (info_label, 1, 1, 2, 1);
+            main_grid.attach (conn_label, 1, 2, 1, 1);
+            main_grid.attach (conn_combo, 2, 2, 1, 1);
+            main_grid.attach (ssid_label, 1, 3, 1, 1);
+            main_grid.attach (ssid_entry, 2, 3, 1, 1);
+            main_grid.attach (key_label, 1, 4, 1, 1);
+            main_grid.attach (key_entry, 2, 4, 1, 1);
+            main_grid.attach (check_btn, 2, 5, 1, 1);
 
-            dumb = new Gtk.Label ("");
-
-            grid.attach_next_to (ssid_label, conn_label, Gtk.PositionType.BOTTOM, 1, 1);
-            grid.attach_next_to (ssid_entry, ssid_label, Gtk.PositionType.RIGHT, 1, 1);
-            grid.attach_next_to (key_label, ssid_label, Gtk.PositionType.BOTTOM, 1, 1);
-            grid.attach_next_to (key_entry, key_label, Gtk.PositionType.RIGHT, 1, 1);
-            grid.attach_next_to (dumb, key_label, Gtk.PositionType.BOTTOM, 1, 1);
-            grid.attach_next_to (check_btn, dumb, Gtk.PositionType.RIGHT, 1, 1);
+            get_content_area ().add (main_grid);
 
             var cancel_btn = new Gtk.Button.with_label (_("Cancel"));
+
             create_btn = new Gtk.Button.with_label (_("Enable Hotspot"));
+            create_btn.get_style_context ().add_class ("suggested-action");
+
             if (active != null) {
                 create_btn.label = _("Switch to Hotspot");
             }
 
-            create_btn.get_style_context ().add_class ("suggested-action");
+            add_action_widget (cancel_btn, 0);
+            add_action_widget (create_btn, 1);
 
-            this.add_action_widget (cancel_btn, 0);
-            this.add_action_widget (create_btn, 1);
-
-            vbox.add (title);
-            vbox.add (info_label);
-            vbox.add (grid);
+            get_action_area ().margin = 5;
 
             update ();
 
-            main_box.add (vbox);
-            content_area.add (main_box);
-            this.show_all ();
+            show_all ();
         }
 
         public ByteArray get_ssid () {
@@ -186,7 +174,6 @@ namespace Network.Widgets {
             key_entry.sensitive = sensitive;
 
             check_btn.sensitive = sensitive;
-            dumb.sensitive = sensitive;
 
             string? secret = null;
             if (get_selected_connection () != null) {


### PR DESCRIPTION
* Use one grid instead of nested grids and boxes
* Remove dummy label "dumb"
* Fix margins and spacing
* Wrap text instead of hardcoding a line break
* Use css style class for primary label instead of pango
* Organize