### PR TITLE
Depend on network-manager-gnome

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -16,7 +16,7 @@ Homepage: https://github.com/elementary/switchboard-plug-networking
 
 Package: switchboard-plug-networking
 Architecture: any
-Depends: ${misc:Depends}, ${shlibs:Depends}
+Depends: network-manager-gnome, ${misc:Depends}, ${shlibs:Depends}
 Enhances: switchboard
 Recommends: network-manager-openvpn-gnome
 Description: Manage network connections


### PR DESCRIPTION
Fixes #108 

We depend on this package to provide the connection editor that is launched when you click the "Settings…" button for a network or the "Edit Connections…" button